### PR TITLE
fix: sanitize file paths to prevent directory traversal attacks

### DIFF
--- a/src/main/java/org/owasp/webgoat/webwolf/FileServer.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/FileServer.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.TimeZone;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -72,11 +73,11 @@ public class FileServer {
     // DO NOT use multipartFile.transferTo(), see
     // https://stackoverflow.com/questions/60336929/java-nio-file-nosuchfileexception-when-file-transferto-is-called
     try (InputStream is = multipartFile.getInputStream()) {
-      var destinationFile = destinationDir.toPath().resolve(multipartFile.getOriginalFilename());
+      var destinationFile = destinationDir.toPath().resolve(FilenameUtils.getName(multipartFile.getOriginalFilename()));
       Files.deleteIfExists(destinationFile);
       Files.copy(is, destinationFile);
     }
-    log.debug("File saved to {}", new File(destinationDir, multipartFile.getOriginalFilename()));
+    log.debug("File saved to {}", new File(destinationDir, FilenameUtils.getName(multipartFile.getOriginalFilename())));
 
     return new ModelAndView(
         new RedirectView("files", true),


### PR DESCRIPTION
## Summary
- Resolves Semgrep rule violation for user input controlling file paths in FileServer.java
- Sanitizes multipart file names using `FilenameUtils.getName()` to prevent directory traversal attacks
- Prevents attackers from using '../' sequences to access files outside the intended directory

## Changes
- Added import for `org.apache.commons.io.FilenameUtils`
- Updated file path resolution to use `FilenameUtils.getName(multipartFile.getOriginalFilename())` 
- Applied sanitization in both the file copy operation and debug logging

## Test plan
- [ ] Verify file upload functionality still works correctly
- [ ] Test that filenames with '../' sequences are properly sanitized
- [ ] Confirm that only the filename portion is preserved (no directory paths)

🤖 Generated with [Claude Code](https://claude.ai/code)