### PR TITLE
fix: replace manual SQL string construction with prepared statements

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java
@@ -42,11 +42,9 @@ public class Assignment5 implements AssignmentEndpoint {
     try (var connection = dataSource.getConnection()) {
       PreparedStatement statement =
           connection.prepareStatement(
-              "select password from challenge_users where userid = '"
-                  + username_login
-                  + "' and password = '"
-                  + password_login
-                  + "'");
+              "select password from challenge_users where userid = ? and password = ?");
+      statement.setString(1, username_login);
+      statement.setString(2, password_login);
       ResultSet resultSet = statement.executeQuery();
 
       if (resultSet.next()) {


### PR DESCRIPTION
## Summary
- Refactored Assignment5.java to use parameterized queries instead of manual string concatenation
- Addresses Semgrep security rule: "User data flows into manually-constructed SQL string"
- Replaces vulnerable SQL string building with secure PreparedStatement parameters

## Changes Made
- Converted manual SQL string concatenation to parameterized query using `?` placeholders
- Added proper parameter binding with `PreparedStatement.setString()`
- Maintained existing functionality while eliminating SQL injection vulnerability

## Security Impact
- **Fixes**: SQL injection vulnerability in user authentication logic
- **Semgrep Rule**: User data flows into manually-constructed SQL string (line 45)
- **Risk Level**: High - Previously allowed potential data manipulation/theft

## Test Plan
- [ ] Verify existing authentication functionality still works correctly
- [ ] Confirm user login with valid credentials succeeds
- [ ] Ensure malicious SQL injection attempts are properly sanitized
- [ ] Run existing unit tests to validate no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)